### PR TITLE
Fixed issue when using local AWS IoT Shadow platforms (like Greengrass)

### DIFF
--- a/src/mgos_aws_shadow.c
+++ b/src/mgos_aws_shadow.c
@@ -564,7 +564,7 @@ bool mgos_aws_shadow_init(void) {
     return false;
   }
   const char *mqtt_server = mgos_sys_config_get_mqtt_server();
-  if (mqtt_server == NULL || strstr(mqtt_server, "amazonaws.com") == NULL) {
+  if (mqtt_server == NULL || (impl == NULL && strstr(mqtt_server, "amazonaws.com") == NULL)) {
     LOG(LL_ERROR, ("MQTT is not configured for AWS, not initialising shadow"));
     return false;
   }


### PR DESCRIPTION
### FIX details
**Problem**: `aws` library initialization fails with error _"MQTT is not configured for AWS, not initialising shadow"_ when using local AWS IoT Shadow platforms like Greegrass.

**Cause**: the library initialization function contains a _strong_ constraint on `mqtt.server` configuration parameter, that must contain the `amazonaws.com` string.

**Fix**: this fix allows you using IP address (e.g. `192.168.1.200`) or private/organization DNS name (e.g. `greengrass.my-domain.com`) as value of the `mqtt.server` configuration parameter.
### Allowed configurations
Some examples of allowed `mos.yml` configurations:
```
config_schema:
  - ["mqtt.server", "192.168.1.200:8883"]
  - ["shadow.lib", "aws"]
```
```
config_schema:
  - ["mqtt.server", "greengrass.my-domain.com:8883"]
  - ["shadow.lib", "aws"]
```
```
config_schema:
  - ["mqtt.server", "xxxxxxxxxxxxxx.iot.eu-west-2.amazonaws.com:8883"]
  - ["shadow.lib", "aws"]
```
```
config_schema:
  - ["mqtt.server", "xxxxxxxxxxxxxx.iot.eu-west-2.amazonaws.com:8883"]
```