### PR TITLE
Fixed SHADOW_GET_REJECTED and SHADOW_UPDATE_REJECTED events not raised

### DIFF
--- a/src/mgos_aws_shadow.c
+++ b/src/mgos_aws_shadow.c
@@ -189,7 +189,7 @@ static enum mgos_aws_shadow_event topic_id_to_aws_ev(
     case MGOS_AWS_SHADOW_TOPIC_GET_ACCEPTED:
       return MGOS_AWS_SHADOW_GET_ACCEPTED;
     case MGOS_AWS_SHADOW_TOPIC_GET_REJECTED:
-      return MGOS_AWS_SHADOW_UPDATE_REJECTED;
+      return MGOS_AWS_SHADOW_GET_REJECTED;
     case MGOS_AWS_SHADOW_TOPIC_UPDATE_ACCEPTED:
       return MGOS_AWS_SHADOW_UPDATE_ACCEPTED;
     case MGOS_AWS_SHADOW_TOPIC_UPDATE_REJECTED:
@@ -418,7 +418,7 @@ static void mgos_aws_shadow_ev(struct mg_connection *nc, int ev, void *ev_data,
                      "{code: %d, message: %Q}", &se.code, &message);
           se.message.p = message ? message : "";
           se.message.len = strlen(message);
-          mgos_event_trigger(topic_id + MGOS_SHADOW_CONNECTED, &se);
+          mgos_event_trigger(MGOS_SHADOW_CONNECTED + topic_id_to_aws_ev(topic_id), &se);
           LOG(LL_ERROR, ("Error: %d %s", se.code, (message ? message : "")));
           mgos_runlock(ss->lock);
           struct error_cb *e;


### PR DESCRIPTION
### FIX Details
**Problem**: when AWS IoT Shadow services reject GET and UPDATE messages, `SHADOW_GET_REJECTED` and `SHADOW_UPDATE_REJECTED` events are not properly raised.

**Cause**: `AWS_SHADOW_UPDATE_REJECTED` ad `AWS_SHADOW_GET_REJECTED` event IDs are not properly converted to the corresponding `shadow` library state IDs.

**Fix**: `aws` library event IDs are now properly converted to `shadow` library event IDs
### How to run into the issue
E.g. execute this in your C: `mgos_shadow_update(0, "{switch: \"%s}");`
A `SHADOW_UPDATE_REJECTED` event should be raised (error message _"Invalid json format"_), but because the event is not raised.